### PR TITLE
add build/ and dist/ to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.pytest_cache
 /.tox
 /venv*
+/build
+/dist


### PR DESCRIPTION
I ran `python setup.py install` and I noticed it created two directories: `build/` and `dist/`. This change to the gitignore will stop them being committed. Duh.