### PR TITLE
Catch unknown commands instead of giving the command

### DIFF
--- a/babi.py
+++ b/babi.py
@@ -616,8 +616,11 @@ def _edit(screen: Screen) -> EditResult:
             response = screen.status.prompt(screen, '')
             if response == ':q':
                 return EditResult.EXIT
-            # TODO: handle response
-            screen.status.update(response, screen.margin)
+            else:
+                screen.status.update(
+                    f'{response} is not a valid command.',
+                    screen.margin,
+                )
         elif key.keyname == b'^S':
             screen.file.save(screen.status, screen.margin)
         elif key.keyname == b'^X':


### PR DESCRIPTION
This stops you typing `:qq` for example, and the status message becoming ":qq". Instead, in an `else`, it'll change the message to "Unknown command: :qq".