### PR TITLE
Commands decorator

### DIFF
--- a/babi.py
+++ b/babi.py
@@ -616,8 +616,11 @@ def _edit(screen: Screen) -> EditResult:
             response = screen.status.prompt(screen, '')
             if response == ':q':
                 return EditResult.EXIT
-            # TODO: handle response
-            screen.status.update(response, screen.margin)
+            else:
+                screen.status.update(
+                    f'{response} is not a valid command.',
+                    screen.margin,
+                )
         elif key.keyname == b'^S':
             screen.file.save(screen.status, screen.margin)
         elif key.keyname == b'^X':

--- a/babi.py
+++ b/babi.py
@@ -179,8 +179,6 @@ class Status:
         return buf
 
 
-EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV NONE')
-
 COMMANDS = {}
 
 def command(name, description):
@@ -613,6 +611,8 @@ def _resize(stdscr: 'curses._CursesWindow', file: File) -> Margin:
     file.maybe_scroll_down(margin)
     return margin
 
+
+EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV')
 
 def _edit(screen: Screen) -> EditResult:
     screen.file.ensure_loaded(screen.status, screen.margin)

--- a/babi.py
+++ b/babi.py
@@ -181,9 +181,10 @@ class Status:
 
 COMMANDS = {}
 
+
 def command(name, description):
     def generator(func):
-        COMMANDS[name] = { 'description': description, 'run': func }
+        COMMANDS[name] = {'description': description, 'run': func}
     return generator
 
 
@@ -613,6 +614,7 @@ def _resize(stdscr: 'curses._CursesWindow', file: File) -> Margin:
 
 
 EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV')
+
 
 def _edit(screen: Screen) -> EditResult:
     screen.file.ensure_loaded(screen.status, screen.margin)

--- a/babi.py
+++ b/babi.py
@@ -179,6 +179,8 @@ class Status:
         return buf
 
 
+EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV NONE')
+
 COMMANDS = {}
 
 def command(name, description):
@@ -190,12 +192,13 @@ def command(name, description):
 @command(':w', 'Writes the file')
 def write_command(screen):
     screen.file.save(screen.status, screen.margin)
-    return 'NONE'
 
 
 @command(':q', 'Quits babi')
 def close_command(screen):
-    return 'EXIT'
+    while screen.files:
+        screen.i = screen.i % len(screen.files)
+        del screen.files[screen.i]
 
 
 def _restore_lines_eof_invariant(lines: List[str]) -> None:
@@ -609,9 +612,6 @@ def _resize(stdscr: 'curses._CursesWindow', file: File) -> Margin:
     margin = Margin.from_screen(stdscr)
     file.maybe_scroll_down(margin)
     return margin
-
-
-EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV NONE')
 
 
 def _edit(screen: Screen) -> EditResult:

--- a/babi.py
+++ b/babi.py
@@ -616,7 +616,7 @@ def _edit(screen: Screen) -> EditResult:
             response = screen.status.prompt(screen, '')
             if response == ':q':
                 return EditResult.EXIT
-            if response == ':w':
+            elif response == ':w':
                 screen.file.save(screen.status, screen.margin)
             else:
                 screen.status.update(

--- a/babi.py
+++ b/babi.py
@@ -616,6 +616,8 @@ def _edit(screen: Screen) -> EditResult:
             response = screen.status.prompt(screen, '')
             if response == ':q':
                 return EditResult.EXIT
+            if response == ':w':
+                screen.file.save(screen.status, screen.margin)
             else:
                 screen.status.update(
                     f'{response} is not a valid command.',

--- a/tests/babi_test.py
+++ b/tests/babi_test.py
@@ -243,11 +243,16 @@ def test_status_clearing_behaviour():
         h.await_text_missing('unknown key')
 
 
-def test_escape_key_behaviour():
-    # TODO: eventually escape will have a command utility, for now: unknown
-    with run() as h, and_exit(h):
-        h.press('Escape')
+def test_quit_via_colon_q():
+    with run() as h:
+        # show a status so we can tell when the command module is up
+        h.press('^J')
         h.await_text('unknown key')
+        h.press('Escape')
+        h.await_text_missing('unknown key')
+        h.press(':q')
+        h.press('Enter')
+        h.await_exit()
 
 
 def test_reacts_to_resize():


### PR DESCRIPTION
We spoke about this on #9, but I made a small implementation of it. It could obviously use some work to get parts of it running better, i.e. not having `:q` quit by causing an error, but for the most part it works fine.

Command instances could be moved to classes eventually, for `.call(screen)` style usage, which would mean better implementation with a keymap system.

Anyway, as this isn't going to be of much use until @asottile needs it or the editor gets more traction, I'm going to create and close the PR until further notice