### PR TITLE
Prevent bashrc interfering in suspend tests

### DIFF
--- a/tests/babi_test.py
+++ b/tests/babi_test.py
@@ -731,7 +731,7 @@ def test_suspend(tmpdir):
     f = tmpdir.join('f')
     f.write('hello')
 
-    with PrintsErrorRunner('env', 'PS1=$ ', 'bash') as h:
+    with PrintsErrorRunner('bash', '--norc') as h:
         cmd = (sys.executable, '-mcoverage', 'run', '-m', 'babi', str(f))
         h.press_and_enter(' '.join(shlex.quote(part) for part in cmd))
         h.await_text(babi.VERSION_STR)
@@ -752,7 +752,7 @@ def test_suspend_with_resize(tmpdir):
     f = tmpdir.join('f')
     f.write('hello')
 
-    with PrintsErrorRunner('env', 'PS1=$', 'bash') as h:
+    with PrintsErrorRunner('bash', '--norc') as h:
         cmd = (sys.executable, '-mcoverage', 'run', '-m', 'babi', str(f))
         h.press_and_enter(' '.join(shlex.quote(part) for part in cmd))
         h.await_text(babi.VERSION_STR)


### PR DESCRIPTION
This stops it creating a custom PS1, and also forces the test to ignore the `.bashrc` of the user.

Should fix/aid timeout issues with test_suspend and test_suspend_with_resize.