### PR TITLE
add mypy to requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage
 git+https://github.com/mjsir911/hecate@092f811
+mypy
 pytest
 remote-pdb


### PR DESCRIPTION
mypy is run in pre-commit, so I think it should be included as a dev dependency so people can use it outside of pre-commit.