### PR TITLE
Command System

### DIFF
--- a/babi.py
+++ b/babi.py
@@ -933,17 +933,17 @@ class Command:
         self.func = func
 
     def translate_keybinds(self) -> List[bytes]:
-        """
-        Translates the keybinds in the form "Modifier-key" to curses-compatible
-        format.
-        """
-        new_binds = []  # type: List[bytes]
+    """
+    Translates the keybinds in the form "Modifier-key" to curses-compatible
+    format.
+    """
+        new_binds: List[bytes] = []
         for bind in self.keybinds:
             new_binds.append(bind.replace('C-', '^').upper().encode('UTF-8'))
         return new_binds
 
 
-COMMANDS = {}  # type: Dict[str, Command]
+COMMANDS: Dict[str, Command] = {} 
 
 
 def command(
@@ -956,6 +956,7 @@ def command(
         COMMANDS[name] = Command(
             name, description, keybinds, func, aliases=aliases,
         )
+        return func
     return inner
 
 

--- a/babi.py
+++ b/babi.py
@@ -1166,11 +1166,11 @@ def _edit(screen: Screen) -> EditResult:
         res = None
 
         bind_found = [
-            [command.binds, command.func]
+            (command.binds, command.func)
             for command in COMMANDS if key.keyname in command.binds
         ]
 
-        cmd: List[Any] = []
+        cmd: Tuple[List[bytes], Callable[[Screen, Key], EditResult]]
         if len(bind_found) > 0:
             cmd = bind_found[0]
 
@@ -1232,6 +1232,7 @@ def _edit(screen: Screen) -> EditResult:
             res = EditResult.EDIT
 
         if not res == EditResult.EDIT:
+            assert res is not None
             return res
 
 

--- a/babi.py
+++ b/babi.py
@@ -951,6 +951,17 @@ def quit_command(screen: Screen) -> EditResult:
     return EditResult.EXIT
 
 
+@command('write', 'Saves the current buffer.', ['C-s'])
+def save_command(screen: Screen) -> None:
+    screen.file.save(screen, screen.status)
+
+
+@command('write-quit', 'Saves the current buffer then quits it.', ['C-o-x'])
+def write_quit_command(screen: Screen) -> EditResult:
+    screen.file.save(screen, screen.status)
+    return EditResult.EXIT
+
+
 def _edit(screen: Screen) -> EditResult:
     prevkey = Key('', 0, b'')
     screen.file.ensure_loaded(screen.status)
@@ -1009,13 +1020,6 @@ def _edit(screen: Screen) -> EditResult:
             response = screen.status.prompt(screen, '')
             if COMMANDS[response[1:]]:
                 return COMMANDS[response[1:]].func(screen)
-            elif response == ':q':
-                return EditResult.EXIT
-            elif response == ':w':
-                screen.file.save(screen, screen.status)
-            elif response == ':wq':
-                screen.file.save(screen, screen.status)
-                return EditResult.EXIT
             elif response != '':  # noop / cancel
                 screen.status.update(f'invalid command: {response}')
         elif key.keyname == b'^S':

--- a/babi.py
+++ b/babi.py
@@ -941,7 +941,7 @@ COMMANDS = {}
 
 def command(name: str, description: str, keybinds: List[str]) -> None:
     def inner(func: Callable[[Screen], EditResult]):
-        COMMANDS[name] = Command(name, description, keybinds)
+        COMMANDS[name] = Command(name, description, keybinds, func)
 
     return inner
 
@@ -1007,12 +1007,12 @@ def _edit(screen: Screen) -> EditResult:
             screen.file.current_position(screen.status)
         elif key.keyname == b'^[':  # escape
             response = screen.status.prompt(screen, '')
-            if COMMANDS.get(response):
-                return COMMANDS.get(response).func(screen)
-            if response == ':q':
+            if COMMANDS[response[1:]]:
+                return COMMANDS[response[1:]].func(screen)
+            elif response == ':q':
                 return EditResult.EXIT
             elif response == ':w':
-                screen.file.savescreen, screen.status)
+                screen.file.save(screen, screen.status)
             elif response == ':wq':
                 screen.file.save(screen, screen.status)
                 return EditResult.EXIT

--- a/babi.py
+++ b/babi.py
@@ -1030,7 +1030,7 @@ def command(
         COMMANDS.append(
             Command(
                 name, description, binds, func, aliases=aliases,
-            )
+            ),
         )
         return func
     return inner
@@ -1096,7 +1096,7 @@ def uncut_command(screen: Screen, prevkey: Key) -> EditResult:
 @command(
     'undo',
     'Undoes your last action.',
-    binds=[b'M-u']
+    binds=[b'M-u'],
 )
 def undo_command(screen: Screen, prevkey: Key) -> EditResult:
     screen.file.undo(screen.status, screen.margin)
@@ -1106,9 +1106,9 @@ def undo_command(screen: Screen, prevkey: Key) -> EditResult:
 @command(
     'redo',
     'Redoes your last action.',
-    binds=[b'M-U']
+    binds=[b'M-U'],
 )
-def undo_command(screen: Screen, prevkey: Key) -> EditResult:
+def redo_command(screen: Screen, prevkey: Key) -> EditResult:
     screen.file.redo(screen.status, screen.margin)
     return EditResult.EDIT
 
@@ -1116,7 +1116,7 @@ def undo_command(screen: Screen, prevkey: Key) -> EditResult:
 @command(
     'go-to-line',
     'Jumps to a specific line in the current buffer',
-    binds=[b'^_']
+    binds=[b'^_'],
 )
 def go_to_line_command(screen: Screen, prevkey: Key) -> EditResult:
     response = screen.status.prompt(screen, 'enter line number')
@@ -1136,7 +1136,7 @@ def go_to_line_command(screen: Screen, prevkey: Key) -> EditResult:
     'search',
     'Searches the current buffer',
     binds=[b'^W'],
-    aliases=['s']
+    aliases=['s'],
 )
 def search_command(screen: Screen, prevkey: Key) -> EditResult:
     response = screen.status.prompt(screen, 'search', history='search')
@@ -1166,8 +1166,10 @@ def _edit(screen: Screen) -> EditResult:
 
         res = None
 
-        bind_found = [[command.binds, command.func]
-                      for command in COMMANDS if key.keyname in command.binds]
+        bind_found = [
+            [command.binds, command.func]
+            for command in COMMANDS if key.keyname in command.binds
+        ]
         cmd = []
         if len(bind_found) > 0:
             cmd = bind_found[0]
@@ -1186,10 +1188,14 @@ def _edit(screen: Screen) -> EditResult:
                 prevkey = key
         elif key.keyname == b'^[':  # escape
             response = screen.status.prompt(screen, '', history='command')
-            cmd_found = [[command.name, command.func]
-                         for command in COMMANDS if response[1:] == command.name]
-            alias_found = [[command.aliases, command.func]
-                           for command in COMMANDS if response[1:] in command.aliases]
+            cmd_found = [
+                [command.name, command.func]
+                for command in COMMANDS if response[1:] == command.name
+            ]
+            alias_found = [
+                [command.aliases, command.func]
+                for command in COMMANDS if response[1:] in command.aliases
+            ]
             cmd = []
             if len(cmd_found) > 0:
                 cmd = cmd_found[0]

--- a/babi.py
+++ b/babi.py
@@ -1194,7 +1194,7 @@ def _edit(screen: Screen) -> EditResult:
         if len(bind_found) > 0:
             cmd = bind_found[0]
         else:
-            cmd = None
+            cmd = None  # type: ignore
 
         if key.key == curses.KEY_RESIZE:
             screen.resize()
@@ -1213,27 +1213,27 @@ def _edit(screen: Screen) -> EditResult:
                 prevkey = key
         elif key.keyname == b'^[':  # escape
             response = screen.status.prompt(screen, '', history='command')
-            cmd_found = [
+            innercmd_found = [
                 (command.name, command.func)
                 for command in COMMANDS if response[1:] == command.name
             ]
-            
-            cmd: Tuple[List[bytes], Callable[[Screen, Key], EditResult]]
 
-            if len(cmd_found) == 0: # Not found, look for alias
+            innercmd: Tuple[List[bytes], Callable[[Screen, Key], EditResult]]
+
+            if len(innercmd_found) == 0:  # Not found, look for alias
                 alias_found = [
                     (command.aliases, command.func)
                     for command in COMMANDS if response[1:] in command.aliases
                 ]
-                if len(alias_found) == 0: # Not found, set to None
-                    cmd = None
+                if len(alias_found) == 0:  # Not found, set to None
+                    innercmd = None
                 else:
-                    cmd = alias_found[0]
+                    innercmd = alias_found[0]
             else:
-                cmd = cmd_found[0]
+                innercmd = innercmd_found[0]
 
-            if cmd:
-                res = cmd[1](screen, prevkey)
+            if innercmd:
+                res = innercmd[1](screen, prevkey)
             elif response != '':  # noop / cancel
                 screen.status.update(f'invalid command: {response}')
                 res = EditResult.EDIT

--- a/babi.py
+++ b/babi.py
@@ -917,17 +917,17 @@ def _get_char(stdscr: 'curses._CursesWindow') -> Key:
 EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV')
 
 
-class Command():
+class Command:
     def __init__(self, name: str, description: str, keybinds: List[str], func: Callable[[Screen], None]) -> None:
         self.name = name
         self.description = description
         self.keybinds = keybinds
         self.func = func
 
-    def getKeybinds():
+    def get_keybinds():
         return self.keybinds
 
-    def translateKeybinds():
+    def translate_keybinds():
         """
         Translates the keybinds in the form "Modifier-key" to curses-compatible
         format.
@@ -936,7 +936,7 @@ class Command():
             print(bind)
 
 
-# type: NamedTuple[Command]
+# type: Dict[str, Command]
 COMMANDS = {}
 
 def command(name: str, description: str, keybinds: List[str]) -> None:

--- a/babi.py
+++ b/babi.py
@@ -1176,12 +1176,15 @@ def _edit(screen: Screen) -> EditResult:
 
         if key.key == curses.KEY_RESIZE:
             screen.resize()
+            res = EditResult.EDIT
         elif key.key in File.DISPATCH:
             screen.file.DISPATCH[key.key](screen.file, screen.margin)
+            res = EditResult.EDIT
         elif key.keyname in File.DISPATCH_KEY:
             screen.file.DISPATCH_KEY[key.keyname](
                 screen.file, screen.margin,
             )
+            res = EditResult.EDIT
         elif cmd:
             if key.keyname in cmd[0]:
                 res = cmd[1](screen, prevkey)
@@ -1208,6 +1211,8 @@ def _edit(screen: Screen) -> EditResult:
             elif response != '':  # noop / cancel
                 screen.status.update(f'invalid command: {response}')
                 res = EditResult.EDIT
+            else:
+                res = EditResult.EDIT
 
         elif key.keyname == b'kLFT3':
             res = EditResult.PREV
@@ -1224,6 +1229,7 @@ def _edit(screen: Screen) -> EditResult:
             res = EditResult.EDIT
         else:
             screen.status.update(f'unknown key: {key}')
+            res = EditResult.EDIT
 
         if not res == EditResult.EDIT:
             return res


### PR DESCRIPTION
## What?

This adds a command system to Babi wherein any editing commands (write, go to line, search, quit, etc.) all share one function, and they're just called differently depending on user input.

For example, a command with the title `quit` and aliases `['q', 'exit']` and keybinds `['C-x']` would allow you to quit by hitting <kbd>ESC `:q`</kbd>, <kbd>ESC `:exit`</kbd>, <kbd>ESC `:quit`</kbd> or <kbd>C-x</kbd>.

## Why?

For the sake of both modularity and scaling.

---

I'm obviously open to any suggestions/improvements/questions, but this should help out quite a lot.