### PR TITLE
Pull version from system metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.9.0
+    rev: v2.1.0
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v1.5.0
+    rev: v2.0.1
     hooks:
     -   id: add-trailing-comma
         args: [--py36-plus]
@@ -34,6 +34,10 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
+-   repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.7.0
+    hooks:
+    -   id: setup-cfg-fmt
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.770
     hooks:

--- a/babi/screen.py
+++ b/babi/screen.py
@@ -27,7 +27,12 @@ from babi.prompt import Prompt
 from babi.prompt import PromptResult
 from babi.status import Status
 
-VERSION_STR = 'babi v0'
+if sys.version_info >= (3, 8):  # pragma: no cover (py38+)
+    import importlib.metadata as importlib_metadata
+else:  # pragma: no cover (<py38)
+    import importlib_metadata
+
+VERSION_STR = f'babi v{importlib_metadata.version("babi")}'
 EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV OPEN')
 
 # TODO: find a place to populate these, surely there's a database somewhere

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ packages = find:
 install_requires =
     identify
     onigurumacffi>=0.0.10
+    importlib_metadata>=1;python_version<"3.8"
 python_requires = >=3.6.1
 
 [options.entry_points]


### PR DESCRIPTION
If you drop Python 3.6 you can, I suppose, move `__version__` into a module-level getattr.

The `# type: ignore` comments are because of https://github.com/python/mypy/issues/1393