### PR TITLE
fix babi crashing on win when trying to run it in the background

### DIFF
--- a/babi/screen.py
+++ b/babi/screen.py
@@ -516,10 +516,13 @@ class Screen:
         return EditResult.EXIT
 
     def background(self) -> None:
-        curses.endwin()
-        os.kill(os.getpid(), signal.SIGSTOP)
-        self.stdscr = _init_screen()
-        self.resize()
+        if sys.platform == 'win32':  # pragma: win32 cover
+            self.status.update('cannot run babi in background on Windows')
+        else:  # pragma: win32 no cover
+            curses.endwin()
+            os.kill(os.getpid(), signal.SIGSTOP)
+            self.stdscr = _init_screen()
+            self.resize()
 
     DISPATCH = {
         b'KEY_RESIZE': resize,


### PR DESCRIPTION
babi does not crash anymore when pressing `CTL_Z` on windows instead displays a message


Maybe you need to write or edit a test for the `CTL_Z` windows shenanigan?