### PR TITLE
add key for redo so it works on win

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ these are all of the current key bindings in babi
 - <kbd>tab</kbd> / <kbd>shift-tab</kbd>: indent or dedent current line (or
   selection)
 - <kbd>^K</kbd> / <kbd>^U</kbd>: cut and uncut the current line (or selection)
-- <kbd>M-u</kbd> / <kbd>M-U</kbd>: undo / redo
+- <kbd>M-u</kbd> / <kbd>M-U</kbd> or <kbd>M-e</kbd>: undo / redo
 - <kbd>^W</kbd>: search
 - <kbd>^\\</kbd>: search and replace
 - <kbd>^C</kbd>: show the current position in the file

--- a/babi/screen.py
+++ b/babi/screen.py
@@ -85,6 +85,7 @@ KEYNAME_REWRITE = {
     b'CTL_END': b'kEND5',
     b'ALT_RIGHT': b'kRIT3',
     b'ALT_LEFT': b'kLFT3',
+    b'ALT_E': b'M-e',
     # windows-curses: idk why these are different
     b'KEY_SUP': b'KEY_SR',
     b'KEY_SDOWN': b'KEY_SF',
@@ -529,6 +530,7 @@ class Screen:
         b'^U': uncut,
         b'M-u': undo,
         b'M-U': redo,
+        b'M-e': redo,
         b'^W': search,
         b'^\\': replace,
         b'^[': command,

--- a/tests/features/undo_redo_test.py
+++ b/tests/features/undo_redo_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from testing.runner import and_exit
 
 
@@ -9,7 +11,8 @@ def test_nothing_to_undo_redo(run):
         h.await_text('nothing to redo!')
 
 
-def test_undo_redo(run):
+@pytest.mark.parametrize('r', ('M-U', 'M-e'))
+def test_undo_redo(run, r):
     with run() as h, and_exit(h):
         h.press('hello')
         h.await_text('hello')
@@ -17,7 +20,7 @@ def test_undo_redo(run):
         h.await_text('undo: text')
         h.await_text_missing('hello')
         h.await_text_missing(' *')
-        h.press('M-U')
+        h.press(r)
         h.await_text('redo: text')
         h.await_text('hello')
         h.await_text(' *')


### PR DESCRIPTION
Now you can redo with `M-e`. Did not work on windows previously.