### PR TITLE
fixed regex replace invalid replace causes crash

### DIFF
--- a/babi/screen.py
+++ b/babi/screen.py
@@ -417,6 +417,10 @@ class Screen:
                 'replace with', history='replace', allow_empty=True,
             )
             if response is not PromptResult.CANCELLED:
+                if response != '':
+                    # escaping last character example backslash '\'
+                    r = response[-1].encode('unicode-escape').decode()
+                    response = response[:-1] + r
                 self.file.replace(self, search_response, response)
 
     def command(self) -> Optional[EditResult]:

--- a/babi/screen.py
+++ b/babi/screen.py
@@ -417,11 +417,10 @@ class Screen:
                 'replace with', history='replace', allow_empty=True,
             )
             if response is not PromptResult.CANCELLED:
-                if response != '':
-                    # escaping last character example backslash '\'
-                    r = response[-1].encode('unicode-escape').decode()
-                    response = response[:-1] + r
-                self.file.replace(self, search_response, response)
+                try:
+                    self.file.replace(self, search_response, response)
+                except re.error:
+                    self.status.update(f'invalid replace text: {response}')
 
     def command(self) -> Optional[EditResult]:
         response = self.prompt('', history='command')

--- a/babi/screen.py
+++ b/babi/screen.py
@@ -411,16 +411,17 @@ class Screen:
             self.file.search(response, self.status, self.margin)
 
     def replace(self) -> None:
+        backslash_re = re.compile(r'^([^\\]*)\\(?!n)(?!1)([^\\]|\\\\)*$')
         search_response = self._get_search_re('search (to replace)')
         if search_response is not PromptResult.CANCELLED:
             response = self.prompt(
                 'replace with', history='replace', allow_empty=True,
             )
             if response is not PromptResult.CANCELLED:
-                try:
-                    self.file.replace(self, search_response, response)
-                except re.error:
+                if backslash_re.match(response):
                     self.status.update(f'invalid replace text: {response}')
+                else:
+                    self.file.replace(self, search_response, response)
 
     def command(self) -> Optional[EditResult]:
         response = self.prompt('', history='command')

--- a/tests/features/replace_test.py
+++ b/tests/features/replace_test.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from testing.runner import and_exit
@@ -306,15 +304,9 @@ def test_replace_with_multiple_newline_characters(run, ten_lines):
 
 @pytest.mark.parametrize(
     'repl, expected', [
-        (r'ohai\ ', 'ohai\\'),
-        (r'a\ga ', 'a\\ga'),
-        pytest.param(
-            r'a\pa ', 'a\\pa',
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 7),
-                reason='fail only on 3.7',
-            ),
-        ),
+        (r'ohai\ ', r'ohai\ '),
+        (r'a\ga ', r'a\ga '),
+        (r'a\pa ', r'a\pa '),
     ],
 )
 def test_replace_replace_with_backslash_crash(run, ten_lines, repl, expected):
@@ -324,6 +316,4 @@ def test_replace_replace_with_backslash_crash(run, ten_lines, repl, expected):
         h.press_and_enter('line_0')
         h.await_text('replace with:')
         h.press_and_enter(repl[:-1])
-        h.await_text('replace [yes, no, all]?')
-        h.press('y')
-        h.await_text(f'invalid replace text: {expected}')
+        h.await_text(f'invalid replace text: {expected[:-1]}')

--- a/tests/features/replace_test.py
+++ b/tests/features/replace_test.py
@@ -300,3 +300,18 @@ def test_replace_with_multiple_newline_characters(run, ten_lines):
 
         h.await_text_missing('line_1')
         h.await_text('li\nne\n1\n\nline_2')
+
+
+def test_replace_replace_with_ending_backslash(run, ten_lines):
+    with run(str(ten_lines)) as h, and_exit(h):
+        h.press('^\\')
+        h.await_text('search (to replace):')
+        h.press_and_enter('line_0')
+        h.await_text('replace with:')
+        h.press_and_enter('ohai\\')
+        h.await_text('replace [yes, no, all]?')
+        h.press('y')
+        h.await_text_missing('line_0')
+        h.await_text('ohai\\')
+        h.await_text(' *')
+        h.await_text('replaced 1 occurrence')


### PR DESCRIPTION
Fixed crash if last character in replacement string was a backslash \.  This fix is hacky.