### PR TITLE
Fix out of bounds on uncomment

### DIFF
--- a/babi/file.py
+++ b/babi/file.py
@@ -681,13 +681,18 @@ class File:
         rest_offset = ws_len + len(prefix)
         if line.startswith(prefix, ws_len):
             self.buf[lineno] = f'{ws_match[0]}{line[rest_offset:].lstrip()}'
+            if self.buf.y == lineno and self.buf.x > ws_len:
+                self.buf.x -= len(line) - len(self.buf[lineno])
 
     def _comment_add(self, lineno: int, prefix: str) -> None:
+        prefix = f'{prefix} '
         line = self.buf[lineno]
         ws_match = WS_RE.match(line)
         assert ws_match is not None
         ws_len = len(ws_match[0])
-        self.buf[lineno] = f'{ws_match[0]}{prefix} {line[ws_len:]}'
+        self.buf[lineno] = f'{ws_match[0]}{prefix}{line[ws_len:]}'
+        if lineno == self.buf.y:
+            self.buf.x += len(prefix)
 
     @edit_action('comment', final=True)
     def toggle_comment(self, prefix: str) -> None:

--- a/tests/features/comment_test.py
+++ b/tests/features/comment_test.py
@@ -73,3 +73,27 @@ def test_comment_with_trailing_whitespace(run, ten_lines):
         h.press_and_enter(':comment //   ')
 
         h.await_text('// line_0\nline_1\n')
+
+
+def test_comment_cursor_at_end_of_line(run, ten_lines):
+    with run(str(ten_lines)) as h, and_exit(h):
+        h.press('# ')
+        h.press('End')
+        h.await_cursor_position(x=8, y=1)
+
+        trigger_command_mode(h)
+        h.press_and_enter(':comment')
+
+        h.await_cursor_position(x=6, y=1)
+
+
+def test_add_comment_moves_cursor(run, ten_lines):
+    with run(str(ten_lines)) as h, and_exit(h):
+        h.press('End')
+
+        h.await_cursor_position(x=6, y=1)
+
+        trigger_command_mode(h)
+        h.press_and_enter(':comment')
+
+        h.await_cursor_position(x=8, y=1)


### PR DESCRIPTION
before it would crash with:

```pytb
Traceback (most recent call last):
  File "/home/asottile/opt/venv/bin/babi", line 8, in <module>
    sys.exit(main())
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 152, in main
    return c_main(stdscr, filenames, positions, stdin, perf)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 57, in c_main
    res = _edit(screen, stdin)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 29, in _edit
    screen.draw()
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/screen.py", line 258, in draw
    self.file.draw(self.stdscr, self.margin)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/file.py", line 838, in draw
    stdscr.insstr(draw_y, 0, self.buf.rendered_line(l_y, margin))
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/buf.py", line 246, in rendered_line
    x = self._cursor_x if idx == self.y else 0
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/buf.py", line 236, in _cursor_x
    return self.line_positions(self.y)[self.x]
IndexError: tuple index out of range
```