### PR TITLE
do not crash if the terminal does not have color support

### DIFF
--- a/babi/color_manager.py
+++ b/babi/color_manager.py
@@ -33,14 +33,17 @@ class ColorManager(NamedTuple):
         return self.raw_color_pair(fg_i, bg_i)
 
     def raw_color_pair(self, fg: int, bg: int) -> int:
-        try:
-            return self.raw_pairs[(fg, bg)]
-        except KeyError:
-            pass
+        if curses.COLORS > 0:
+            try:
+                return self.raw_pairs[(fg, bg)]
+            except KeyError:
+                pass
 
-        n = self.raw_pairs[(fg, bg)] = len(self.raw_pairs) + 1
-        curses.init_pair(n, fg, bg)
-        return n
+            n = self.raw_pairs[(fg, bg)] = len(self.raw_pairs) + 1
+            curses.init_pair(n, fg, bg)
+            return n
+        else:
+            return 0
 
     @classmethod
     def make(cls) -> 'ColorManager':

--- a/tests/features/conftest.py
+++ b/tests/features/conftest.py
@@ -303,6 +303,7 @@ class DeferredRunner:
         self.color_pairs = {0: (7, 0)}
         self.screen = Screen(width, height)
         self._n_colors, self._can_change_color = {
+            'xterm-mono': (0, False),
             'screen': (8, False),
             'screen-256color': (256, False),
             'xterm-256color': (256, True),

--- a/tests/features/syntax_highlight_test.py
+++ b/tests/features/syntax_highlight_test.py
@@ -153,3 +153,8 @@ def test_syntax_highlighting_tabs_after_line_creation(run, tmpdir):
         h.press('Enter')
 
         h.await_text('foo\n    x\nx\ny\n')
+
+
+def test_does_not_crash_with_no_color_support(run):
+    with run(term='xterm-mono') as h, and_exit(h):
+        pass


### PR DESCRIPTION
this is how it used to crash before:

```console
$ TERM=xterm-mono nano
Traceback (most recent call last):
  File "/home/asottile/opt/venv/bin/babi", line 8, in <module>
    sys.exit(main())
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 152, in main
    return c_main(stdscr, filenames, positions, stdin, perf)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 53, in c_main
    screen = Screen(stdscr, filenames, positions, perf)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/screen.py", line 115, in __init__
    self.hl_factories = (Syntax.from_screen(stdscr, self.color_manager),)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/hl/syntax.py", line 164, in from_screen
    ret._init_screen(stdscr)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/hl/syntax.py", line 152, in _init_screen
    pair = self.color_manager.color_pair(default_fg, default_bg)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/color_manager.py", line 33, in color_pair
    return self.raw_color_pair(fg_i, bg_i)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/color_manager.py", line 42, in raw_color_pair
    curses.init_pair(n, fg, bg)
_curses.error: init_pair() returned ERR
```