### PR TITLE
Add checks for UTF-8

### DIFF
--- a/babi/file.py
+++ b/babi/file.py
@@ -236,7 +236,7 @@ class File:
             sio = io.StringIO(stdin)
             lines, self.nl, mixed, self.sha256 = get_lines(sio)
         elif self.filename is not None and os.path.isfile(self.filename):
-            with open(self.filename, newline='') as f:
+            with open(self.filename, encoding='UTF-8', newline='') as f:
                 lines, self.nl, mixed, self.sha256 = get_lines(f)
         else:
             if self.filename is not None:

--- a/babi/highlight.py
+++ b/babi/highlight.py
@@ -688,7 +688,7 @@ class Grammars:
             pass
 
         grammar_path = self._scope_to_files.pop(scope)
-        with open(grammar_path) as f:
+        with open(grammar_path, encoding='UTF-8') as f:
             ret = self._raw[scope] = json.load(f)
 
         file_types = frozenset(ret.get('fileTypes', ()))

--- a/babi/history.py
+++ b/babi/history.py
@@ -19,7 +19,8 @@ class History:
         history_dir = xdg_data('history')
         os.makedirs(history_dir, exist_ok=True)
         for filename in os.listdir(history_dir):
-            with open(os.path.join(history_dir, filename)) as f:
+            history_filename = os.path.join(history_dir, filename)
+            with open(history_filename, encoding='UTF-8') as f:
                 self.data[filename] = f.read().splitlines()
                 self._orig_len[filename] = len(self.data[filename])
         try:
@@ -28,5 +29,6 @@ class History:
             for k, v in self.data.items():
                 new_history = v[self._orig_len[k]:]
                 if new_history:
-                    with open(os.path.join(history_dir, k), 'a+') as f:
+                    history_filename = os.path.join(history_dir, k)
+                    with open(history_filename, 'a+', encoding='UTF-8') as f:
                         f.write('\n'.join(new_history) + '\n')

--- a/babi/main.py
+++ b/babi/main.py
@@ -133,7 +133,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if '-' in args.filenames:
         print('reading stdin...', file=sys.stderr)
-        stdin = sys.stdin.read()
+        stdin = sys.stdin.buffer.read().decode()
         tty = os.open(CONSOLE, os.O_RDONLY)
         os.dup2(tty, sys.stdin.fileno())
     else:

--- a/babi/perf.py
+++ b/babi/perf.py
@@ -36,7 +36,7 @@ class Perf:
     def save_profiles(self, filename: str) -> None:
         assert self._prof is not None
         self._prof.dump_stats(f'{filename}.pstats')
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='UTF-8') as f:
             f.write('μs\tevent\n')
             for name, duration in self._records:
                 f.write(f'{int(duration * 1000 * 1000)}\t{name}\n')

--- a/babi/screen.py
+++ b/babi/screen.py
@@ -483,7 +483,7 @@ class Screen:
                 self.file.filename = filename
 
         if os.path.isfile(self.file.filename):
-            with open(self.file.filename, newline='') as f:
+            with open(self.file.filename, encoding='UTF-8', newline='') as f:
                 *_, sha256 = get_lines(f)
         else:
             sha256 = hashlib.sha256(b'').hexdigest()
@@ -496,7 +496,7 @@ class Screen:
             self.status.update('(file changed on disk, not implemented)')
             return PromptResult.CANCELLED
 
-        with open(self.file.filename, 'w', newline='') as f:
+        with open(self.file.filename, 'w', encoding='UTF-8', newline='') as f:
             f.write(contents)
 
         self.file.modified = False

--- a/babi/textmate_demo.py
+++ b/babi/textmate_demo.py
@@ -37,7 +37,7 @@ def _highlight_output(theme: Theme, compiler: Compiler, filename: str) -> int:
 
     if theme.default.bg is not None:
         print('\x1b[48;2;{r};{g};{b}m'.format(**theme.default.bg._asdict()))
-    with open(filename) as f:
+    with open(filename, encoding='UTF-8') as f:
         for line_idx, line in enumerate(f):
             first_line = line_idx == 0
             state, regions = highlight_line(compiler, state, line, first_line)
@@ -54,7 +54,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument('filename')
     args = parser.parse_args(argv)
 
-    with open(args.filename) as f:
+    with open(args.filename, encoding='UTF-8') as f:
         first_line = next(f, '')
 
     theme = Theme.from_filename(args.theme)

--- a/babi/theme.py
+++ b/babi/theme.py
@@ -147,5 +147,5 @@ class Theme(NamedTuple):
         if not os.path.exists(filename):
             return cls.blank()
         else:
-            with open(filename) as f:
+            with open(filename, encoding='UTF-8') as f:
                 return cls.from_dct(json.load(f))


### PR DESCRIPTION
Resolves #78

Add "encoding='UTF-8'" to open() calls
Add check if stdin can be decoded as UTF-8

I wasn't sure how reading from stdin would be utilized so I might totally miss the point here 