### PR TITLE
fix keys for new windows terminal

### DIFF
--- a/babi/screen.py
+++ b/babi/screen.py
@@ -38,6 +38,8 @@ EditResult = enum.Enum('EditResult', 'EXIT NEXT PREV OPEN')
 SEQUENCE_KEYNAME = {
     '\x1bOH': b'KEY_HOME',
     '\x1bOF': b'KEY_END',
+    '\x1b[1~': b'KEY_HOME',
+    '\x1b[4~': b'KEY_END',
     '\x1b[1;2A': b'KEY_SR',
     '\x1b[1;2B': b'KEY_SF',
     '\x1b[1;2C': b'KEY_SRIGHT',
@@ -60,6 +62,7 @@ SEQUENCE_KEYNAME = {
     '\x1b[1;6D': b'kLFT6',  # Shift + ^Left
     '\x1b[1;6H': b'kHOM6',  # Shift + ^Home
     '\x1b[1;6F': b'kEND6',  # Shift + ^End
+    '\x1b[~': b'KEY_BTAB',  # Shift + Tab
 }
 KEYNAME_REWRITE = {
     # windows-curses: numeric pad arrow keys


### PR DESCRIPTION
I tried using the new windows terminal to ssh into a Ubuntu 18.04 machine.
When using babi some keys were not working 😢 :
- <kbd>home</kbd> and <kbd>end</kdb>
- <kbd>shift-tab</kbd>

I tried to fix this by adding the sequences to the know keynames.