### PR TITLE
tests: fix AttributeErrors raised from hecate side

### DIFF
--- a/testing/runner.py
+++ b/testing/runner.py
@@ -70,6 +70,8 @@ def to_attrs(screen, width):
 class PrintsErrorRunner(Runner):
     def __init__(self, *args, **kwargs):
         self._prev_screenshot = None
+        self.shutdown_called = False
+        self.report_file = '/tmp/report.txt'
         super().__init__(*args, **kwargs)
 
     def screenshot(self, *args, **kwargs):
@@ -208,6 +210,10 @@ class PrintsErrorRunner(Runner):
         except AssertionError:  # pragma: no cover (only on failure)
             self.screenshot()
             raise
+
+    def __del__(self):
+       self.shutdown_called = True
+
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This change was needed to get my py.test run complete with 100 % pass rate.

Please note that I am unaware of the report_file usage and how hecate works. This might be a totally wrong way to fix the issue, but it did the trick for me. A large number of tests were failing with the `master` version due to hecate code expecting the two attributes now added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asottile/babi/102)
<!-- Reviewable:end -->
