### PR TITLE
Familiar forward deletion keyboard shortcut Ctrl-D (#101)

### DIFF
--- a/babi/screen.py
+++ b/babi/screen.py
@@ -96,6 +96,7 @@ KEYNAME_REWRITE = {
     b'^?': b'KEY_BACKSPACE',
     # linux, perhaps others
     b'^H': b'KEY_BACKSPACE',  # ^Backspace on my keyboard
+    b'^D': b'KEY_DC',
     b'PADENTER': b'^M',  # Enter on numpad
 }
 

--- a/tests/features/conftest.py
+++ b/tests/features/conftest.py
@@ -290,6 +290,7 @@ KEYS = [
     Key('^_', b'^_', '\x1f'),
     Key('^\\', b'^\\', '\x1c'),
     Key('!resize', b'KEY_RESIZE', curses.KEY_RESIZE),
+    Key('^D', b'^D', '\x04'),
 ]
 KEYS_TMUX = {k.tmux: k.wch for k in KEYS}
 KEYS_CURSES = {k.value: k.curses for k in KEYS}

--- a/tests/features/text_editing_test.py
+++ b/tests/features/text_editing_test.py
@@ -72,14 +72,15 @@ def test_delete_at_end_of_file(run, tmpdir):
         h.await_text_missing('*')
 
 
-def test_delete_removes_character_afterwards(run, tmpdir):
+@pytest.mark.parametrize('key', ('DC', '^D'))
+def test_delete_removes_character_afterwards(run, tmpdir, key):
     f = tmpdir.join('f')
     f.write('hello world')
 
     with run(str(f)) as h, and_exit(h):
         h.await_text('hello world')
         h.press('Right')
-        h.press('DC')
+        h.press(key)
         h.await_text('hllo world')
         h.await_text('f *')
 


### PR DESCRIPTION
With help of the mapping rules, this is easily implemented and all the unit tests will also test usage of Ctrl-D already as Del char behaves similarly.

I have tested this change locally. I don't know if makes sense to duplciate existing delete char unit tests to cover usage of this character also.

