### PR TITLE
add automatic tabsize detection

### DIFF
--- a/babi/buf.py
+++ b/babi/buf.py
@@ -1,5 +1,6 @@
 import bisect
 import contextlib
+import re
 from typing import Callable
 from typing import Generator
 from typing import Iterator
@@ -60,7 +61,7 @@ class Buf:
     def __init__(self, lines: List[str], tab_size: int = 4) -> None:
         self._lines = lines
         self.expandtabs = True
-        self.tab_size = tab_size
+        self.tab_size = self.get_tab_size(tab_size)
         self.file_y = self.y = self._x = self._x_hint = 0
 
         self._set_callbacks: List[SetCallback] = [self._set_cb]
@@ -137,6 +138,16 @@ class Buf:
         """
         if self[-1] != '':
             self.append('')
+
+    def get_tab_size(self, tab_size: int) -> int:
+        for line in self._lines:
+            file_tab_size = re.search(r'(?=.*\S)^\s+', line)
+            if file_tab_size is not None:
+                # if hard tabs are detected use default
+                if not file_tab_size.group(0).startswith('\t'):
+                    tab_size = len(file_tab_size.group(0))
+                break
+        return tab_size
 
     def set_tab_size(self, tab_size: int) -> None:
         self.tab_size = tab_size

--- a/tests/buf_test.py
+++ b/tests/buf_test.py
@@ -176,3 +176,20 @@ def test_buf_pop_idx():
     buf.apply(modifications)
 
     assert lst == ['a', 'b', 'c']
+
+
+@pytest.mark.parametrize(
+    ('lines', 'exp_tab_size'),
+    (
+        pytest.param(['a', '  b', '    c'], 2, id='not_default'),
+        pytest.param(['a', '\tb', 'c'], 4, id='hard_tab'),
+        pytest.param(['a', 'b', 'c'], 4, id='unknown'),
+        pytest.param(['a', '    ', '  b'], 2, id='tr_ws_first'),
+        pytest.param(['a', '\t\t', '\tb'], 4, id='tr_ws_first_hard_tab'),
+        pytest.param(['a', '  ', 'b'], 4, id='tr_ws_unknown'),
+        pytest.param([], 4, id='empty'),
+    ),
+)
+def test_buf_get_tabsize(lines, exp_tab_size):
+    buf = Buf(lines)
+    assert buf.tab_size == exp_tab_size

--- a/tests/features/indent_test.py
+++ b/tests/features/indent_test.py
@@ -80,12 +80,12 @@ def test_dedent_exactly_one_indent(run):
 
 def test_dedent_selection(run, tmpdir):
     f = tmpdir.join('f')
-    f.write('1\n  2\n        3\n')
+    f.write('1\n    2\n        3\n  4\n')
     with run(str(f)) as h, and_exit(h):
         for _ in range(3):
             h.press('S-Down')
         h.press('BTab')
-        h.await_text('\n1\n2\n    3\n')
+        h.await_text('\n1\n2\n    3\n4\n')
 
 
 def test_dedent_selection_with_noexpandtabs(run, tmpdir):


### PR DESCRIPTION
Hi,
I tried implementing an automatic `tabsize` detection when opening a file.
- I added a few test cases for the tabsize detection
- I had to modify the `test_dedent_selection` test, because the tab size was detected as 2 tabs. I think it actually wants to test that lines are properly dedented, even if the indentation is smaller than the currently set `tab_size` right? I think the test still does this now?


I am not sure if this detection will fit all different kinds of files or if the file type has to be taken into consideration...