### PR TITLE
fix crashing on permission denied error

### DIFF
--- a/babi/screen.py
+++ b/babi/screen.py
@@ -508,8 +508,14 @@ class Screen:
             self.status.update('(file changed on disk, not implemented)')
             return PromptResult.CANCELLED
 
-        with open(self.file.filename, 'w', encoding='UTF-8', newline='') as f:
-            f.write(contents)
+        try:
+            with open(
+                self.file.filename, 'w', encoding='UTF-8', newline='',
+            ) as f:
+                f.write(contents)
+        except OSError as e:
+            self.status.update(f'cannot save file: {e}')
+            return PromptResult.CANCELLED
 
         self.file.modified = False
         self.file.sha256 = sha256_to_save

--- a/tests/features/save_test.py
+++ b/tests/features/save_test.py
@@ -128,6 +128,18 @@ def test_save_file_when_it_did_not_exist(run, tmpdir):
     assert f.read() == 'hello world\n'
 
 
+def test_saving_file_permission_denied(run, tmpdir):
+    f = tmpdir.join('f').ensure()
+    f.chmod(0o400)
+
+    with run(str(f)) as h, and_exit(h):
+        h.press('hello world')
+        h.press('^S')
+        # the filename message is missing as it is too long to be captured
+        h.await_text('cannot save file: [Errno 13] Permission denied:')
+        h.await_text(' *')
+
+
 def test_save_via_ctrl_o(run, tmpdir):
     f = tmpdir.join('f')
     with run(str(f)) as h, and_exit(h):


### PR DESCRIPTION
When opening a file with read permissions but no write permission, babi would crash when trying to save it. Now a message is displayed instead and it is possible to save the file at a different location so the changes made are not lost.