### PR TITLE
Change Syntax Highlightert on save with known extension.

### DIFF
--- a/babi/file.py
+++ b/babi/file.py
@@ -219,7 +219,7 @@ class File:
             *,
             is_stdin: bool,
     ) -> None:
-        self.filename = filename
+        self._filename = filename
         self.initial_line = initial_line
         self.is_stdin = is_stdin
         self.modified = False
@@ -236,6 +236,15 @@ class File:
         self._replace_hl = Replace()
         self.selection = Selection()
         self._file_hls: tuple[FileHL, ...] = ()
+
+    @property
+    def filename(self) -> str | None:
+        return self._filename
+
+    @filename.setter
+    def filename(self, value: str) -> None:
+        self._filename = value
+        self._initialize_highlighters()
 
     def ensure_loaded(
             self,


### PR DESCRIPTION
I am using babi in different way than you usually starting from babi. When I save file the syntax highliting is not enabled and i have to close and reopen file. I added simple setter on filename to initialize syntax highlighter. Hope I do not mess with tests :)