### PR TITLE
Change of behavour of Right command for 1 space at the start of line

### DIFF
--- a/babi/file.py
+++ b/babi/file.py
@@ -376,7 +376,7 @@ class File:
         # if we're inside the line, jump to next position that's not our type
         else:
             self.buf.right(dim)
-            tp = line[self.buf.x].isalnum()
+            tp = line[self.buf.x].isalnum() and line[self.buf.x - 1] != '\t'
             while self.buf.x < len(line) and tp == line[self.buf.x].isalnum():
                 self.buf.right(dim)
 

--- a/tests/features/movement_test.py
+++ b/tests/features/movement_test.py
@@ -545,3 +545,66 @@ yet_another_test = None
 
         h.press('M-Down')
         h.await_cursor_position(x=0, y=12)
+
+
+def test_ctrl_right_jump_with_tabs(run, tmpdir):
+    src = '''\
+\tHello\tWorld
+\t\tGoodday
+hi\t\tAnthonk
+as\tHello
+Helloa\tdsa\tasd
+\t\t\tthis(is_some_code)  # comment
+'''
+    f = tmpdir.join('f')
+    f.write(src)
+    with run(str(f)) as h, and_exit(h):
+        h.press('^Right')
+        h.await_cursor_position(x=4, y=1)
+        h.press('^Right')
+        h.await_cursor_position(x=9, y=1)
+        h.press('Left')
+        h.await_cursor_position(x=8, y=1)
+        h.press('^Right')
+        h.await_cursor_position(x=12, y=1)
+        h.press('^Right')
+        h.await_cursor_position(x=17, y=1)
+        h.press('^Right')
+        h.await_cursor_position(x=8, y=2)
+        h.press('^Right')
+        h.await_cursor_position(x=15, y=2)
+        h.press('^Right')
+        h.await_cursor_position(x=0, y=3)
+        h.press('^Right')
+        h.await_cursor_position(x=2, y=3)
+        h.press('^Right')
+        h.await_cursor_position(x=8, y=3)
+        h.press('^Right')
+        h.await_cursor_position(x=15, y=3)
+        h.press('^Right')
+        h.await_cursor_position(x=0, y=4)
+        h.press('^Right')
+        h.await_cursor_position(x=2, y=4)
+        h.press('Left')
+        h.await_cursor_position(x=1, y=4)
+        h.press('^Right')
+        h.await_cursor_position(x=4, y=4)
+        h.press('^Right')
+        h.await_cursor_position(x=9, y=4)
+        h.press('^Right')
+        h.await_cursor_position(x=0, y=5)
+        h.press('^Right')
+        h.await_cursor_position(x=6, y=5)
+        h.press('^Right')
+        h.await_cursor_position(x=8, y=5)
+        h.press('^Right')
+        h.await_cursor_position(x=11, y=5)
+        h.press('^Right')
+        h.await_cursor_position(x=12, y=5)
+        h.press('^Right')
+        h.await_cursor_position(x=15, y=5)
+        h.press('^Right')
+        h.await_cursor_position(x=12, y=6)
+        h.press('Down')
+        h.press('^Right')
+        h.await_cursor_position(x=0, y=7)


### PR DESCRIPTION
Target #237 
The problem is for all spaces uses at the start of the line. PR target only those, and not changing behaviour of the rest. It should work for any characters recognized by the isspace method. 