### PR TITLE
made sure babi uses pre-commit config when different repo

### DIFF
--- a/babi/linters/pre_commit.py
+++ b/babi/linters/pre_commit.py
@@ -67,12 +67,12 @@ class PreCommit:
             return None
 
         return (
-            'pre-commit',
-            'run',
-            '--config=".pre-commit-config.yaml"',
-            '--color=never',
-            '--files', filename,
-        )
+                'pre-commit', 
+                'run', 
+                '--config=' + os.path.join(root, '.pre-commit-config.yaml'),
+                '--color=never', 
+                '--files', filename
+                )
 
     def parse(self, filename: str, output: str) -> tuple[linting.Error, ...]:
         root = self._root(filename)

--- a/babi/linters/pre_commit.py
+++ b/babi/linters/pre_commit.py
@@ -67,12 +67,12 @@ class PreCommit:
             return None
 
         return (
-                'pre-commit', 
-                'run', 
-                '--config=' + os.path.join(root, '.pre-commit-config.yaml'),
-                '--color=never', 
-                '--files', filename
-                )
+            'pre-commit',
+            'run',
+            '--config=' + os.path.join(root, '.pre-commit-config.yaml'),
+            '--color=never',
+            '--files', filename,
+        )
 
     def parse(self, filename: str, output: str) -> tuple[linting.Error, ...]:
         root = self._root(filename)

--- a/babi/linters/pre_commit.py
+++ b/babi/linters/pre_commit.py
@@ -67,12 +67,12 @@ class PreCommit:
             return None
 
         return (
-                'pre-commit', 
-                'run', 
-                '--config=".pre-commit-config.yaml"', 
-                '--color=never', 
-                '--files', filename
-                )
+            'pre-commit',
+            'run',
+            '--config=".pre-commit-config.yaml"',
+            '--color=never',
+            '--files', filename,
+        )
 
     def parse(self, filename: str, output: str) -> tuple[linting.Error, ...]:
         root = self._root(filename)

--- a/babi/linters/pre_commit.py
+++ b/babi/linters/pre_commit.py
@@ -66,7 +66,13 @@ class PreCommit:
         if not os.path.exists(os.path.join(root, '.pre-commit-config.yaml')):
             return None
 
-        return ('pre-commit', 'run', '--color=never', '--files', filename)
+        return (
+                'pre-commit', 
+                'run', 
+                '--config=".pre-commit-config.yaml"', 
+                '--color=never', 
+                '--files', filename
+                )
 
     def parse(self, filename: str, output: str) -> tuple[linting.Error, ...]:
         root = self._root(filename)

--- a/tests/linters/pre_commit_test.py
+++ b/tests/linters/pre_commit_test.py
@@ -100,11 +100,11 @@ def test_command_returns_when_config_exists(tmpdir_git):
     path = str(tmpdir_git.join('t.py'))
     ret = PreCommit().command(path, 'source.python')
     assert ret == (
-            'pre-commit', 'run',
-            '--config=".pre-commit-config.yaml"',
-            '--color=never',
-            '--files', path
-            )
+        'pre-commit', 'run',
+        '--config=".pre-commit-config.yaml"',
+        '--color=never',
+        '--files', path,
+    )
 
 
 def test_filters_file_paths_to_actual_file(tmpdir_git):

--- a/tests/linters/pre_commit_test.py
+++ b/tests/linters/pre_commit_test.py
@@ -99,7 +99,12 @@ def test_command_returns_when_config_exists(tmpdir_git):
     tmpdir_git.join('.pre-commit-config.yaml').write('{}\n')
     path = str(tmpdir_git.join('t.py'))
     ret = PreCommit().command(path, 'source.python')
-    assert ret == ('pre-commit', 'run', '--color=never', '--files', path)
+    assert ret == (
+            'pre-commit', 'run',
+            '--config=".pre-commit-config.yaml"',
+            '--color=never',
+            '--files', path
+            )
 
 
 def test_filters_file_paths_to_actual_file(tmpdir_git):

--- a/tests/linters/pre_commit_test.py
+++ b/tests/linters/pre_commit_test.py
@@ -100,11 +100,11 @@ def test_command_returns_when_config_exists(tmpdir_git):
     path = str(tmpdir_git.join('t.py'))
     ret = PreCommit().command(path, 'source.python')
     assert ret == (
-        'pre-commit', 'run',
-        '--config=".pre-commit-config.yaml"',
-        '--color=never',
-        '--files', path,
-    )
+            'pre-commit', 'run',
+            '--config=' + str(tmpdir_git.join(".pre-commit-config.yaml")),
+            '--color=never',
+            '--files', path
+            )
 
 
 def test_filters_file_paths_to_actual_file(tmpdir_git):

--- a/tests/linters/pre_commit_test.py
+++ b/tests/linters/pre_commit_test.py
@@ -100,11 +100,11 @@ def test_command_returns_when_config_exists(tmpdir_git):
     path = str(tmpdir_git.join('t.py'))
     ret = PreCommit().command(path, 'source.python')
     assert ret == (
-            'pre-commit', 'run',
-            '--config=' + str(tmpdir_git.join(".pre-commit-config.yaml")),
-            '--color=never',
-            '--files', path
-            )
+        'pre-commit', 'run',
+        '--config=' + str(tmpdir_git.join('.pre-commit-config.yaml')),
+        '--color=never',
+        '--files', path,
+    )
 
 
 def test_filters_file_paths_to_actual_file(tmpdir_git):


### PR DESCRIPTION
Hello @asottile,
I tried to fix the issue #256. It seemed like the only thing we needed was adding the config to the pre-commit return statement.

However I was not sure to either put it in a variable or just inline it so for now it is inlined. I can change this if you would like.

I also changed the formatting of the return statement. flake8 was complaining about the line being too long so I split it up.

Please let me know if you want any other changes, thanks!

P.S. My python sucks let me know if things are not pythonic..