### PR TITLE
Fixed babi not using babi_grammars when installed in a venv

### DIFF
--- a/babi/hl/syntax.py
+++ b/babi/hl/syntax.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import curses
 import functools
 import math
+import babi_grammars
 from typing import Callable
 from typing import NamedTuple
 
@@ -19,6 +20,7 @@ from babi.user_data import prefix_data
 from babi.user_data import xdg_config
 from babi.user_data import xdg_data
 
+from pathlib import Path
 
 class FileSyntax:
     include_edge = False
@@ -148,7 +150,7 @@ class Syntax(NamedTuple):
             stdscr: curses._CursesWindow,
             color_manager: ColorManager,
     ) -> Syntax:
-        grammars = Grammars(prefix_data('grammar_v1'), xdg_data('grammar_v1'))
+        grammars = Grammars(prefix_data('grammar_v1'), xdg_data('grammar_v1'), Path(babi_grammars.__spec__.origin).parent.joinpath("share/babi/grammar_v1"))
         theme = Theme.from_filename(xdg_config('theme.json'))
         ret = cls(grammars, theme, color_manager)
         ret._init_screen(stdscr)

--- a/babi/hl/syntax.py
+++ b/babi/hl/syntax.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import curses
 import functools
 import math
-import babi_grammars
+from pathlib import Path
 from typing import Callable
 from typing import NamedTuple
+
+import babi_grammars
 
 from babi.buf import Buf
 from babi.color_manager import ColorManager
@@ -20,7 +22,6 @@ from babi.user_data import prefix_data
 from babi.user_data import xdg_config
 from babi.user_data import xdg_data
 
-from pathlib import Path
 
 class FileSyntax:
     include_edge = False
@@ -150,7 +151,13 @@ class Syntax(NamedTuple):
             stdscr: curses._CursesWindow,
             color_manager: ColorManager,
     ) -> Syntax:
-        grammars = Grammars(prefix_data('grammar_v1'), xdg_data('grammar_v1'), Path(babi_grammars.__spec__.origin).parent.joinpath("share/babi/grammar_v1"))
+        grammars = Grammars(
+            prefix_data('grammar_v1'), xdg_data('grammar_v1'),
+            str(
+                Path(babi_grammars.__spec__.origin).parent
+                .joinpath('share/babi/grammar_v1'),
+            ),
+        )
         theme = Theme.from_filename(xdg_config('theme.json'))
         ret = cls(grammars, theme, color_manager)
         ret._init_screen(stdscr)


### PR DESCRIPTION
(This is a new pull-request, since I somehow screwed the last one up, sorry about that 😊)

When installing babi in a venv, located somewhere on your pc, it won't pick up babi_grammar's existence,
because the path isn't being searched and therefore syntax highlighting won't work.
This PR tries to fix this by importing babi_grammar and using its path to find the correct `grammar_v1` folder.

`babi_grammars.__spec__.origin` gives us an absolute path to `babi_grammars.py`. From there we go to the parent directory and into `share/babi/grammar_v1`